### PR TITLE
Add P3P and its ransac variant

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MultivariatePolynomials = "102ac46a-7ee4-5c85-9060-abc95bfdeaa3"
+Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RowEchelon = "af85af4c-bcd5-5d23-b03a-a909639aa875"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/src/FivePoint.jl
+++ b/src/FivePoint.jl
@@ -1,5 +1,6 @@
 module FivePoint
-export five_point, five_point_ransac, p3p
+export five_point, five_point_ransac
+export p3p_select_model, p3p, p3p_ransac
 
 using Random
 using LinearAlgebra

--- a/src/FivePoint.jl
+++ b/src/FivePoint.jl
@@ -1,5 +1,5 @@
 module FivePoint
-export five_point, five_point_ransac
+export five_point, five_point_ransac, p3p
 
 using Random
 using LinearAlgebra

--- a/src/FivePoint.jl
+++ b/src/FivePoint.jl
@@ -7,6 +7,9 @@ using StaticArrays
 using TypedPolynomials
 using MultivariatePolynomials
 using RowEchelon
+import Polynomials
+
+const PPolynomial = Polynomials.Polynomial
 
 @polyvar x y z
 
@@ -15,5 +18,7 @@ include("ransac.jl")
 include("five_point/utils.jl")
 include("five_point/chirality.jl")
 include("five_point/five_point.jl")
+
+include("pnp/p3p.jl")
 
 end

--- a/src/five_point/five_point.jl
+++ b/src/five_point/five_point.jl
@@ -38,16 +38,22 @@ function five_point(p1, p2)
 end
 
 function five_point_ransac(p1, p2; ransac_kwargs...)
+    sample_selection(sample_ids) = (p1[sample_ids], p2[sample_ids])
+    rank(models) = select_candidates(models, p1, p2)
     ransac(
-        (p1, p2), five_point_candidates, select_candidates, 5;
+        sample_selection, five_point_candidates, rank,
+        length(p1), 5;
         ransac_kwargs...
     )
 end
 
 function five_point_ransac(p1, p2, K1, K2; ransac_kwargs...)
+    p1, p2 = pre_divide(p1, p2, K1, K2)
+    sample_selection(sample_ids) = (p1[sample_ids], p2[sample_ids])
+    rank(models) = select_candidates(models, p1, p2)
     ransac(
-        pre_divide(p1, p2, K1, K2),
-        five_point_candidates, select_candidates, 5;
+        sample_selection, five_point_candidates, rank,
+        length(p1), 5;
         ransac_kwargs...
     )
 end

--- a/src/pnp/p3p.jl
+++ b/src/pnp/p3p.jl
@@ -1,0 +1,94 @@
+"""
+pixels: K^-1 [u v 1]^T / ||K^-1 [u v 1]^T||
+"""
+function p3p(points, pixels, K)
+    ϵ = 1e-4
+
+    d12 = norm(points[1] .- points[2])
+    d13 = norm(points[1] .- points[3])
+    d23 = norm(points[2] .- points[3])
+    (d12 < ϵ || d13 < ϵ || d23 < ϵ) && return nothing
+
+    sd12, sd13, sd23 = d12^2, d13^2, d23^2
+
+    α12 = pixels[1] ⋅ pixels[2]
+    α13 = pixels[1] ⋅ pixels[3]
+    α23 = pixels[2] ⋅ pixels[3]
+
+    # Compute coefficients of a polynomial [7.80].
+    m1, m2 = sd12, sd13 - sd23
+    p1 = PPolynomial([0, -2 * α23 * sd12])
+    p2 = PPolynomial([2 * α13 * sd23, - 2 * α23 * sd13])
+    q1 = sd23 * PPolynomial([1, - 2 * α12, 1]) + PPolynomial([0, 0, -sd12])
+    q2 = PPolynomial([sd23, 0, -sd13])
+
+    P = (m1 * q2 - m2 * q1)^2 - (m1 * p2 - m2 * p1) * (q1 * p2 - q2 * p1)
+    P_roots = P |> Polynomials.roots
+
+    models = SMatrix{3, 4, Float64}[]
+
+    for η12 in P_roots
+        η12 ≤ 0 && continue
+        # Evaluate [7.89] at η12 to get η13.
+        η13 = (m1 * q2 - m2 * q1)(η12) / (m1 * p2 - m2 * p1)(η12)
+        # [7.91 - 7.93].
+        denom = 1 + η12^2 - 2 * η12 * α12
+        denom ≤ 0 && continue
+        η1 = d12 / √denom
+        η2 = η1 * η12
+        η3 = η1 * η13
+        (η1 ≤ 0 || η2 ≤ 0 || η3 ≤ 0) && continue
+        # Compute and check errors.
+        (
+            abs((√(η1^2 + η2^2 - 2 * η1 * η2 * α12) - d12) / d12) > ϵ ||
+            abs((√(η1^2 + η3^2 - 2 * η1 * η3 * α13) - d13) / d13) > ϵ ||
+            abs((√(η2^2 + η3^2 - 2 * η2 * η3 * α23) - d23) / d23) > ϵ
+        ) && continue
+
+        nx1 = η1 * pixels[1]
+        z2 = η2 * pixels[2] - nx1; z2 /= norm(z2)
+        z3 = η3 * pixels[3] - nx1; z3 /= norm(z3)
+        z1 = z2 × z3; z1 /= norm(z1)
+        z3z1 = z3 × z1
+
+        zw2 = @. (points[2] - points[1]) / d12
+        zw3 = @. (points[3] - points[1]) / d31
+        zw1 = zw2 × zw3; zw1 /= norm(zw1)
+        zw3zw1 = zw3 × zw1
+
+        # Recover rotation R [7.130 - 7.134].
+        Z = SMatrix{3, 3, Float64}(z1..., z2..., z3z1...)
+        ZW = SMatrix{3, 3, Float64}(zw1..., zw2..., zw3zw1...)
+        # TODO check if this is correct or should:
+        # https://github.com/opencv/opencv/blob/68d15fc62edad980f1ffa15ee478438335f39cc3/modules/calib3d/src/usac/utils.cpp#L138
+        R = Z * int(ZW)
+        KR = K * R
+        t = -KR * (points[1] - R' * nx1)
+        push!(models, SMatrix{3, 4, Float64}(KR..., t...))
+    end
+    models
+end
+
+Random.seed!(0)
+
+function main()
+    n = 3
+    
+    pmin, pmax = SVector{3}(-1, -1, 5), SVector{3}(1, 1, 10)
+    point_cloud = [rand(SVector{3, Float64}) .* (pmax .- pmin) .+ pmin for _ in 1:n]
+    
+    fcmin, fcmax = 1e-3, 100
+    K = SMatrix{3, 3, Float64}(
+        rand() * (fcmax - fcmin) + fcmin, 0, 0,
+        0, rand() * (fcmax - fcmin) + fcmin, 0,
+        rand() * (fcmax - fcmin) + fcmin, rand() * (fcmax - fcmin) + fcmin, 1,
+    )
+
+    @info "K"
+    display(K); println()
+
+    models = p3p(point_cloud, point_cloud, K)
+    @info models
+end
+
+main()

--- a/test/p3p.jl
+++ b/test/p3p.jl
@@ -1,0 +1,46 @@
+function backproject_transform(pixels, K_inv, R, t)
+    points = Vector{SVector{3, Float64}}(undef, length(pixels))
+    for (i, px) in enumerate(pixels)
+        p = K_inv * SVector{3, Float64}(px[1], px[2], 1)
+        p = R * p + t
+        points[i] = p
+    end
+    points
+end
+
+@testset "P3P with minor noise." begin
+    n_points = 10
+    noise_scale = 1e-6
+    
+    fcmin, fcmax = 1e-3, 100
+    K = SMatrix{3, 3, Float64}(
+        rand() * (fcmax - fcmin) + fcmin, 0, 0,
+        0, rand() * (fcmax - fcmin) + fcmin, 0,
+        rand() * (fcmax - fcmin) + fcmin, rand() * (fcmax - fcmin) + fcmin, 1,
+    )
+    K_inv = K |> inv
+
+    R = SMatrix{3, 3, Float64}(I)
+    t = SVector{3, Float64}(1, 2, 3)
+
+    max_res = 2 * min(K[1, 3], K[2, 3])
+    pmin = SVector{2}(1, 1)
+    pmax = SVector{2}(max_res, max_res)
+    δ = pmax - pmin
+
+    pixels = [floor.(rand(SVector{2, Float64}) .* δ .+ pmin) for i in 1:n_points]
+    pdn_pixels = FivePoint.pre_divide_normalize(pixels, K)
+    points = backproject_transform(pixels, K_inv, R, t)
+    points = [p .+ rand(SVector{3, Float64}) .* 1e-6 for p in points]
+
+    models = p3p(points[1:3], pdn_pixels[1:3], K)
+    n_inliers, (P, inliers, error) = FivePoint.reprojection_error(
+        models, pixels, points,
+    )
+
+    @test n_inliers == n_points
+    @test sum(inliers) == n_inliers
+    @test all(isapprox.(
+        K_inv * P, FivePoint.get_transformation(R', -t); atol=1e-3,
+    ))
+end

--- a/test/p3p.jl
+++ b/test/p3p.jl
@@ -22,6 +22,7 @@ end
 
     R = SMatrix{3, 3, Float64}(I)
     t = SVector{3, Float64}(1, 2, 3)
+    P_target = FivePoint.get_transformation(R', -t)
 
     max_res = 2 * min(K[1, 3], K[2, 3])
     pmin = SVector{2}(1, 1)
@@ -29,18 +30,86 @@ end
     δ = pmax - pmin
 
     pixels = [floor.(rand(SVector{2, Float64}) .* δ .+ pmin) for i in 1:n_points]
-    pdn_pixels = FivePoint.pre_divide_normalize(pixels, K)
+    pdn_pixels = FivePoint.pre_divide_normalize(pixels, K, :xy)
     points = backproject_transform(pixels, K_inv, R, t)
-    points = [p .+ rand(SVector{3, Float64}) .* 1e-6 for p in points]
+    points = [p .+ rand(SVector{3, Float64}) .* noise_scale for p in points]
 
     models = p3p(points[1:3], pdn_pixels[1:3], K)
-    n_inliers, (P, inliers, error) = FivePoint.reprojection_error(
-        models, pixels, points,
-    )
-
+    n_inliers, (KP, inliers, error) = p3p_select_model(models, points, pixels)
     @test n_inliers == n_points
     @test sum(inliers) == n_inliers
-    @test all(isapprox.(
-        K_inv * P, FivePoint.get_transformation(R', -t); atol=1e-3,
-    ))
+    @test all(isapprox.(K_inv * KP, P_target; atol=1e-2))
+
+    models = p3p(points[1:3], pdn_pixels[1:3], K)
+    n_inliers, (KP, inliers, error) = p3p_select_model(models, points, pixels)
+    @test n_inliers == n_points
+    @test sum(inliers) == n_inliers
+    @test all(isapprox.(K_inv * KP, P_target; atol=1e-2))
+    
+    # Test P3P RANSAC.
+
+    n_inliers, (KP, inliers, error) = p3p_ransac(points, pixels, pdn_pixels, K)
+    @test n_inliers == n_points
+    @test sum(inliers) == n_inliers
+    @test all(isapprox.(K_inv * KP, P_target; atol=1e-2))
+
+    n_inliers, (KP, inliers, error) = p3p_ransac(points, pixels, K, :xy)
+    @test n_inliers == n_points
+    @test sum(inliers) == n_inliers
+    @test all(isapprox.(K_inv * KP, P_target; atol=1e-2))
+end
+
+@testset "P3P RANSAC with noise and outliers." begin
+    n_points = 50
+    noise_scale = 1e-3
+    rot_atol = 0.5
+    t_atol = 2
+    
+    fcmin, fcmax = 1e-3, 100
+    K = SMatrix{3, 3, Float64}(
+        rand() * (fcmax - fcmin) + fcmin, 0, 0,
+        0, rand() * (fcmax - fcmin) + fcmin, 0,
+        rand() * (fcmax - fcmin) + fcmin, rand() * (fcmax - fcmin) + fcmin, 1,
+    )
+    K_inv = K |> inv
+
+    R = SMatrix{3, 3, Float64}(I)
+    t = SVector{3, Float64}(1, 2, 3)
+    P_target = FivePoint.get_transformation(R', -t)
+
+    max_res = 2 * min(K[1, 3], K[2, 3])
+    pmin = SVector{2}(1, 1)
+    pmax = SVector{2}(max_res, max_res)
+    δ = pmax - pmin
+
+    pixels = [floor.(rand(SVector{2, Float64}) .* δ .+ pmin) for i in 1:n_points]
+    pdn_pixels = FivePoint.pre_divide_normalize(pixels, K, :xy)
+    points = backproject_transform(pixels, K_inv, R, t)
+    points = [p .+ rand(SVector{3, Float64}) .* noise_scale for p in points]
+
+    # Add outliers.
+    outlier_scale = 5
+    points[1] = points[1] .+ rand() * outlier_scale
+    points[5] = points[5] .+ rand() * outlier_scale
+    points[end] = points[end] .+ rand() * outlier_scale
+    points[end - 5] = points[end - 5] .+ rand() * outlier_scale
+    points[n_points ÷ 2] = points[n_points ÷ 2] .+ rand() * outlier_scale
+
+    n_inliers, (KP, inliers, error) = p3p_ransac(points, pixels, pdn_pixels, K)
+    P = K_inv * KP
+    @test n_inliers ≥ n_points - 10
+    @test !inliers[1] && !inliers[5] && !inliers[end] && !inliers[end - 5] &&
+        !inliers[n_points ÷ 2]
+
+    @test all(isapprox.(P[1:3, 1:3], P_target[1:3, 1:3]; atol=rot_atol))
+    @test all(isapprox.(P[1:3, 4], P_target[1:3, 4]; atol=t_atol))
+
+    n_inliers, (KP, inliers, error) = p3p_ransac(points, pixels, K, :xy)
+    P = K_inv * KP
+    @test n_inliers ≥ n_points - 10
+    @test !inliers[1] && !inliers[5] && !inliers[end] && !inliers[end - 5] &&
+        !inliers[n_points ÷ 2]
+
+    @test all(isapprox.(P[1:3, 1:3], P_target[1:3, 1:3]; atol=rot_atol))
+    @test all(isapprox.(P[1:3, 4], P_target[1:3, 4]; atol=t_atol))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,8 @@ using Random
 
 Random.seed!(0)
 
+include("p3p.jl")
+
 function get_random_transform()
     # Rotation angle in radians.
     θ = (rand() - 0.5) * π * 360 / 180


### PR DESCRIPTION
- Add P3P (Perspective-3-Point) solver for the case with known camera intrinsics.
- Add P3P Ransac variant to deal with noisy data.
- Improve ransac method to be more general.
- Add tests for P3P and update tests for `five_point_ransac`.